### PR TITLE
Rust App Dockerfile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "hello_cargo"
+name = "hello_rust"
 version = "1.0.0"
 authors = ["Jorgen Thelin <jthelin@example.com>"]
 edition = "2018"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+## Build with command [from repo root directory]:
+# docker build --tag hellorust . --file ./Dockerfile
+##
+## Run with command:
+# docker run --rm -it hellorust cargo run --release Jorgen
+##
+
+# Rust toolchain container, to build and run a rust application.
+
+FROM rust:latest
+
+ARG APP_HOME_DIR=/home/app
+
+WORKDIR $APP_HOME_DIR
+COPY . .
+
+RUN rustc --version && cargo --version && rustup --version
+
+RUN cargo install --path .
+
+CMD cargo run


### PR DESCRIPTION
Add `Dockerfile` for building and running the app using the official Docker Hub `rust` container image.

https://hub.docker.com/_/rust/