### PR TITLE
GitHub Super-Linter

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -10,4 +10,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - run: shellcheck *.sh
+      - run: shellcheck ./*.sh

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,0 +1,43 @@
+name: Lint Code Base
+
+# Documentation:
+# https://help.github.com/en/articles/workflow-syntax-for-github-actions
+
+#############################
+# Start the job on all push #
+#############################
+on:
+  push:
+    branches-ignore: [master, main]
+    # Remove the line above to run when pushing to master
+  pull_request:
+    branches: [master, main]
+
+###############
+# Set the Job #
+###############
+jobs:
+  super-linter:
+    name: Lint Code Base
+
+    runs-on: ubuntu-latest
+
+    steps:
+      ##########################
+      # Checkout the code base #
+      ##########################
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+
+      ################################
+      # Run Linter against code base #
+      ################################
+      - name: Lint Code Base
+        uses: github/super-linter@v4.8.1
+        env:
+          VALIDATE_ALL_CODEBASE: true
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,4 @@ modules.xml
 
 # End of https://www.gitignore.io/api/clion+all
 
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 
 # Latest rust stable release image.
 # https://hub.docker.com/_/rust/
-FROM rust:latest
+FROM rust:1.56.1
 
 # Latest rust nightly release image.
 # https://hub.docker.com/r/rustlang/rust/
@@ -22,6 +22,9 @@ COPY . .
 
 RUN rustc --version && cargo --version && rustup --version
 
+# DL3059 info: Multiple consecutive RUN instructions. Consider consolidation.
+# hadolint ignore=DL3059
+
 RUN cargo install --path .
 
-CMD cargo run
+CMD [ "cargo", "run" ]

--- a/run-superlinter.sh
+++ b/run-superlinter.sh
@@ -4,4 +4,4 @@
 CMD_HOME=$( dirname "$(realpath -s "$0")" )
 REPO_ROOT=${CMD_HOME}
 
-docker build --tag hellorust "${REPO_ROOT}" --file "${REPO_ROOT}/Dockerfile"
+docker run -e RUN_LOCAL=true -v "${REPO_ROOT}":/tmp/lint github/super-linter:v4


### PR DESCRIPTION
- Add github action to run github super-linter on the code base.
  https://github.com/github/super-linter

- Add `run-superlinter.sh` script to run lint checks locally.

- Fix various code lint issues flagged by super-linter